### PR TITLE
Fix speaking dots when pressing space

### DIFF
--- a/addon/globalPlugins/pcKbBrl.py
+++ b/addon/globalPlugins/pcKbBrl.py
@@ -229,7 +229,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				pass
 			self._gesture = None
 		else:
-			if self._oneHandMode and self._speakDot:
+			if (
+				self._oneHandMode and self._speakDot
+				and isinstance(self._dot, int)
+			):
 				brailleInput.speakDots(self._dot)
 		return False
 


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
When pressing space and dots should be spoken, an non handled exception is raised
### Description of how this pull request fixes the issue:
Makes dots not to be spoken when they aren't a number
### Testing performed:
Tested locally pressing space and dots in One hand mode with Speaking dots option enabled.
### Known issues with pull request:
None
### Change log entry:
* Fix error when trying to speak dots if a space is pressed in One hand mode.