### PR TITLE
fixCyrillic

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,10 @@ Unfortunately, there is nothing that can be done to fix this, as the keys are si
 In some cases, using the upper row of keys with either or both hands might help, as your keyboard may allow these keys.
 
 
+## Changes for 28.0.0
+
+* Changed default values for One hand mode.
+
 ## Changes for 2023.02.23
 
 * Added ability to configure keys used to type dots in one hand mode.


### PR DESCRIPTION
- Make add-on usable with Russian keyboard
- Update readme

<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
Braille from PC cannot be enabled with Russian keyboard.

[Report on the add-ons mailing list](https://nvda-addons.groups.io/g/nvda-addons/message/21700)
### Description of how this pull request fixes the issue:
- self._confirmGesture has been replaced by a function to execute the braille gesture after timeout.
- No confirmKeys and cancelKeys will be set by default.
- In the add-on settings panel, isValid has been updated to require at least a confirmkey if timeout is 0.

### Testing performed:
Tested locally with Russian keyboard.
### Known issues with pull request:
Since default values have been changed, some people mey require to update their settings.
### Change log entry:
* Default values have been changed for One hand mode.
