### PR TITLE
Handle gesture exceptions

### DIFF
--- a/addon/globalPlugins/pcKbBrl.py
+++ b/addon/globalPlugins/pcKbBrl.py
@@ -161,11 +161,15 @@ class Dot:
 		keyboardLanguage = GlobalPlugin.getKeyboardLanguage()
 		dotCodes = []
 		for key in dotKeys:
-			gesture = keyboardHandler.KeyboardInputGesture.fromName(key.lower())
-			code = gesture.vkCode
-			if keyboardLanguage in VKCODES.keys() and code in VKCODES[keyboardLanguage].keys():
-				code = VKCODES[keyboardLanguage][code]
-			dotCodes.append(code)
+			try:
+				gesture = keyboardHandler.KeyboardInputGesture.fromName(key.lower())
+			except LookupError:
+				gesture = None
+			if gesture:
+				code = gesture.vkCode
+				if keyboardLanguage in VKCODES.keys() and code in VKCODES[keyboardLanguage].keys():
+					code = VKCODES[keyboardLanguage][code]
+				dotCodes.append(code)
 		return set(dotCodes)
 
 
@@ -239,11 +243,15 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		nullKeys = config.conf["pcKbBrl"]["nullKeys"]
 		nullKeyCodes = []
 		for key in nullKeys:
-			gesture = keyboardHandler.KeyboardInputGesture.fromName(key.lower())
-			code = gesture.vkCode
-			if self._keyboardLanguage in VKCODES.keys() and code in VKCODES[self._keyboardLanguage].keys():
-				code = VKCODES[self._keyboardLanguage][code]
-			nullKeyCodes.append(code)
+			try:
+				gesture = keyboardHandler.KeyboardInputGesture.fromName(key.lower())
+			except LookupError:
+				gesture = None
+			if gesture:
+				code = gesture.vkCode
+				if self._keyboardLanguage in VKCODES.keys() and code in VKCODES[self._keyboardLanguage].keys():
+					code = VKCODES[self._keyboardLanguage][code]
+				nullKeyCodes.append(code)
 		return set(nullKeyCodes)
 
 	def enable(self):


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None. Followup of PR #12
### Summary of the issue:
If a key configured for dots, cancel or confirm doesn't exist in the current keyboard language, not handled exceptions maybe reised.
### Description of how this pull request fixes the issue:
Handle these exceptions: if the gesture cannot be created with specificcharacters, don't use it to get the code.
### Testing performed:
Tested locally.
### Known issues with pull request:
None. As always, we should consider the keyboard language.
### Change log entry:
None.