### PR TITLE
Prepare for NVDA 2023.2

### DIFF
--- a/addon/globalPlugins/pcKbBrl.py
+++ b/addon/globalPlugins/pcKbBrl.py
@@ -383,7 +383,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		ui.message(message, speechPriority=speech.priorities.Spri.NOW)
 
 	def onSettings(self, evt):
-		gui.mainFrame._popupSettingsDialog(NVDASettingsDialog, AddonSettingsPanel)
+		gui.mainFrame.popupSettingsDialog(NVDASettingsDialog, AddonSettingsPanel)
 
 	@script(
 		# Translators: Describes a command.

--- a/buildVars.py
+++ b/buildVars.py
@@ -27,9 +27,9 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName": "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3")
-	"addon_minimumNVDAVersion": "2019.3.0",
+	"addon_minimumNVDAVersion": "2023.2.0",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2023.1.0",
+	"addon_lastTestedNVDAVersion": "2023.2.0",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel": None,
 }


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
pupupSettingsDialog is public in NVDA 2023.2
### Description of how this pull request fixes the issue:
Use the public function and update buildVars to declare that NVDA 2023.2 will be required.
### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
* Requires NVDA 2023.2 or later.