### PR TITLE
Import Settings Panel from gui.nvdaSettingsDialogs

### DIFF
--- a/addon/globalPlugins/pcKbBrl.py
+++ b/addon/globalPlugins/pcKbBrl.py
@@ -22,7 +22,8 @@ import keyboardHandler
 import brailleInput
 import globalCommands
 import gui
-from gui import SettingsPanel, NVDASettingsDialog, guiHelper, nvdaControls
+from gui import NVDASettingsDialog, guiHelper, nvdaControls
+from gui.settingsDialogs import SettingsPanel
 from scriptHandler import script
 from logHandler import log
 import addonHandler


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
SettingsPanel shouldn't be imported directly from gui
### Description of how this pull request fixes the issue:
Import SettingsPanel from gui.settingsDialogs
### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
None